### PR TITLE
Increase retries

### DIFF
--- a/testcases/testcases_sanity/common_sanity_methods.py
+++ b/testcases/testcases_sanity/common_sanity_methods.py
@@ -24,6 +24,8 @@ L3OUT2_NET=conf.get('secondary_L3out_net')
 L3OUT2_VRF=conf.get('secondary_L3out_vrf')
 KEY_AUTH_IP = conf.get('keystone_ip')
 
+max_traff_attempts = conf.get('traffic_attempts', 5)
+
 # Initialize logging
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
@@ -1162,7 +1164,7 @@ class sendTraffic(object):
                    iter+=1
                    #Sleep for 1s and re-run traffic again
                    sleep(1)
-                   if iter > 2:
+                   if iter > max_traff_attempts:
                         failed_traff = 1
                         break
                else:
@@ -1272,7 +1274,7 @@ class sendTraffic(object):
                    iter+=1
                    #Sleep for 1s and re-run traffic again
                    sleep(1)
-                   if iter > 2:
+                   if iter > max_traff_attempts:
                         failed_traff = 1
                         break
                else:


### PR DESCRIPTION
The number of retries needed for some sanity methods needs to
be increased, in order to allow for convergence.