### PR TITLE
Support stable/pike

### DIFF
--- a/testcases/testcases_nat_func/natfunctestmethod.py
+++ b/testcases/testcases_nat_func/natfunctestmethod.py
@@ -82,7 +82,6 @@ PRS_TCP = 'PrsTcp'
 gbpcrud = GBPCrud(CNTRLRIP)
 gbpnova = gbpNova(CNTRLRIP)
 neutron = neutronCli(CNTRLRIP, username=CTRLR_USER, password=CTRLR_PSWD)
-keystone = Keystone(KEY_AUTH_IP)
 
 class NatFuncTestMethods(object):
     """


### PR DESCRIPTION
The test library needs to be fixed to handle OSP12
deployments. These include changes for:

1) restart docker containers, not services, if
   configuration file indicates services are
   containerized
2) increase time for VMs to come up (can back this
   out later if this gets fixed)
3) use nova python client installed on this host,
   instead of controller, as we can install a version
   that supports the old commands (though we should
   fix this in future releases).