### PR TITLE
Fix address scope get

### DIFF
--- a/libs/neutron.py
+++ b/libs/neutron.py
@@ -365,9 +365,11 @@ class neutronCli(object):
 	self.runcmd(cmd) 	   		
 	
     def addscopecrud(self, name, action, tenant='admin', ip=4,
-		     shared=False, apicvrf=''):
+		     shared=False, apicvrf='', otherargs=None):
         if action == 'get':
             cmd = 'neutron --os-project-name %s address-scope-show %s' %(tenant,name)
+            if otherargs:
+                cmd = cmd + otherargs
             return self.runcmd(cmd)
         if action == 'create':
 	    if shared:
@@ -378,12 +380,16 @@ class neutronCli(object):
 			 'address-scope-create %s %s ' %(name,ip)
 	    if apicvrf:
                 cmd = cmd + " %s%s'" %(VRF_PREFIX,apicvrf)
+            if otherargs:
+                cmd = cmd + otherargs
 	    ascId = self.getuuid(self.runcmd(cmd))
 	    if ascId:
 	       #print 'Output of ID ==\n', ascId
 	       return ascId
 	if action == 'delete':
 	   cmd = 'neutron --os-project-name %s address-scope-delete %s' %(tenant,name)
+           if otherargs:
+               cmd = cmd + otherargs
            self.runcmd(cmd)
 
     def subpoolcrud(self,name,action,address_scope='', pool='',

--- a/testcases/testcases_sanity/common_sanity_methods.py
+++ b/testcases/testcases_sanity/common_sanity_methods.py
@@ -317,10 +317,12 @@ class crudML2(object):
 					        tenant=tnt,
 					        shared=shared)
             if is_dual_stack():
+                vrfargs = ' -c apic:distinguished_names -f value'
                 v4scope = neutron.addscopecrud(addscopename,
                                                'get',
                                                tenant=tnt,
-                                               shared=shared)
+                                               shared=shared,
+                                               otherargs=vrfargs)
                 regex = r'"VRF": "(.*)"'
                 found = re.search(regex, v4scope)
                 self.addscopIDv6 = neutron.addscopecrud(addscopename_v6,


### PR DESCRIPTION
The dual-stack test was failing when retrieving an address scope,
as the regular expression match failed b/c of a newline. This uses
a column-specific get to retrieve the AIM extension data, which
avoids any newlines.