### PR TITLE
Use proper connection tracking

### DIFF
--- a/libs/gbp_pexp_traff_libs.py
+++ b/libs/gbp_pexp_traff_libs.py
@@ -228,7 +228,12 @@ class gbpExpTraffHping3(object):
 			 if self.parse_ping_output(result,self.pkt_cnt) !=0:
 			    results[dest_ep]['tcp']=1
 			 else:
-			    results[dest_ep]['tcp']=0
+                            # Disregard if we passed SYN, but fail any with ACK
+                            # (connection tracking expects SYN only as first packet)
+                            if "-A" in cmd and results[dest_ep]['tcp'] == 1:
+                               results[dest_ep]['tcp']=1
+                            else:
+                               results[dest_ep]['tcp']=0
 		   else:
 			#Over-riding the label cmd_s,to run simple ncat
 			cmd_s = "nc -w 1 -v %s -z 22" %(dest_ep)


### PR DESCRIPTION
The east-west test was failing after a fix was made to the opflex-agent.
The issue was that the test was allowing TCP sessions to pass, even though
the security groups were configured with reflexive policies. The agent was
fixed to properly implement connection tracking, which means that the TCP
sessions that start with something other than just a SYN should fail.