### PR TITLE
Fix FAB2021 template

### DIFF
--- a/testcases/f2021-director.yaml
+++ b/testcases/f2021-director.yaml
@@ -13,12 +13,12 @@ heat_dp_stack_name: 'dpstack'
 heat_dp_nat_stack_name: 'dpnatstack'
 key_name: 'gbpkey' #Ensure that it is same as mentioned in heat template
 apic_system_id: 'ostack-pt-1-s1'
-primary_L3out: 'os-pt-1-s1-l3out-1' #Ensure to keep these names as is
-primary_L3out_net: 'os-pt-1-s1-l3out-epg' #Ensure to keep these names as is
+primary_L3out: 'os-pt-1-s1_l3out-1' #Ensure to keep these names as is
+primary_L3out_net: 'os-pt-1-s1_l3out-1_epg' #Ensure to keep these names as is
 primary_L3out_vrf: 'sauto_ostack-pt-1-s1_l3out-1_vrf' #Ensure to keep these names as is
-secondary_L3out: 'os-pt-1-s1-l3out-2'
-secondary_L3out_net: 'os-pt-1-s1-l3out-2-epg'
-secondary_L3out_vrf: 'sauto_ostack-pt-1_s1_l3out-2-vrf'
+secondary_L3out: 'os-pt-1-s1_l3out-2'
+secondary_L3out_net: 'os-pt-1-s1_l3out-2_epg'
+secondary_L3out_vrf: 'sauto_ostack-pt-1-s1_l3out-2_vrf'
 keystone_user: 'admin'
 keystone_ip: ""
 keystone_password: 'noir0123'
@@ -36,7 +36,7 @@ neutronconffile: '/etc/neutron/neutron.conf' #Ensure it has the VALID apic_exter
 network_node: "1.100.1.41"
 az_comp_node: 'overcloud-novacompute-0.localdomain'
 compute-2: 'overcloud-novacompute-1.localdomain'
-ext_rtr: '10.30.120.197'
+ext_rtr: '10.30.120.203'
 gwip1_extrtr: '1.252.1.254'
 gwip2_extrtr: '1.253.1.254'
 extrtr_ip1: '1.252.1.1'


### PR DESCRIPTION
The template for FAB2021 was using the incorrect L3 out name for the no-NAT L3 Out (should be using underscore instead of hyphen).