### PR TITLE
Adjust traffic test timeouts

### DIFF
--- a/testcases/testcases_sanity/common_sanity_methods.py
+++ b/testcases/testcases_sanity/common_sanity_methods.py
@@ -1194,8 +1194,8 @@ class sendTraffic(object):
             while True:
                if not vm_traff.run_and_verify_traffic(proto,tcp_syn_only=1,no_ipv6=no_ipv6):
                    iter+=1
-                   #Sleep for 1s and re-run traffic again
-                   sleep(1)
+                   #Sleep for 5s and re-run traffic again
+                   sleep(5)
                    if iter > max_traff_attempts:
                         failed_traff = 1
                         break
@@ -1304,8 +1304,8 @@ class sendTraffic(object):
             while True:
                if not vm_traff.run_and_verify_traffic(proto,tcp_syn_only=1):
                    iter+=1
-                   #Sleep for 1s and re-run traffic again
-                   sleep(1)
+                   #Sleep for 5s and re-run traffic again
+                   sleep(5)
                    if iter > max_traff_attempts:
                         failed_traff = 1
                         break


### PR DESCRIPTION
With the introduction of the "thundering herd" fix in the proxy, the delay for resolving policies on the agent needs to be increased, as the policy usually needs to be re-requested from the leaf, increasing the overall policy resolution time (and therefore time before the data plane has converged).